### PR TITLE
Add prop to customize animation duration and fix thumbButton not toggling on initial render

### DIFF
--- a/src/__test__/toggle.test.js
+++ b/src/__test__/toggle.test.js
@@ -373,7 +373,7 @@ describe('Toggle Component', () => {
 
       getByTestId('ToggleButton').props.onPress();
 
-      expect(setToggleValue).toHaveBeenCalledTimes(1);
+      expect(setToggleValue).toHaveBeenCalledTimes(2);
 
       fireEvent.press(getByTestId('ToggleButton'));
 
@@ -399,7 +399,7 @@ describe('Toggle Component', () => {
 
       getByTestId('ToggleButton').props.onLongPress();
 
-      expect(setToggleValue).toHaveBeenCalledTimes(1);
+      expect(setToggleValue).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/toggle.js
+++ b/src/toggle.js
@@ -108,6 +108,7 @@ const ReactNativeToggleElement = (props) => {
     thumbStyle,
     leftTitle,
     rightTitle,
+    animationDuration
   } = props;
 
   const [toggleValue, setToggleValue] = useState(value);
@@ -120,7 +121,7 @@ const ReactNativeToggleElement = (props) => {
 
     Animated.timing(fadeAnim, {
       toValue,
-      duration: 350,
+      duration: animationDuration,
       useNativeDriver: true,
     }).start();
   };
@@ -290,6 +291,7 @@ ReactNativeToggleElement.propTypes = {
   thumbStyle: ViewPropTypes.style,
   leftTitle: PropTypes.string,
   rightTitle: PropTypes.string,
+  animationDuration: PropTypes.number
 };
 
 ReactNativeToggleElement.defaultProps = {
@@ -328,6 +330,7 @@ ReactNativeToggleElement.defaultProps = {
     color: COLOR_DEFAULT.disable,
   },
   thumbStyle: null,
+  animationDuration: 350
 };
 
 const styles = StyleSheet.create({

--- a/src/toggle.js
+++ b/src/toggle.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import {
   Animated,
   StyleSheet,
@@ -113,6 +113,14 @@ const ReactNativeToggleElement = (props) => {
 
   const [toggleValue, setToggleValue] = useState(value);
 
+  useEffect(() => {
+    updateThumbButton(toggleValue)
+  }, [toggleValue])
+
+  useEffect(() => {
+    setToggleValue(value);
+  }, [value])
+
   const updateThumbButton = (toggleState) => {
     const thumbBtnWidth = thumbButton.width ?? SIZE_DEFAULT.thumbBtnWidth;
     const trackBarW = trackBar.width ?? SIZE_DEFAULT.trackBarWidth;
@@ -131,7 +139,6 @@ const ReactNativeToggleElement = (props) => {
     const val = !toggleValue;
     setToggleValue(val);
     onPress(val);
-    updateThumbButton(val);
   };
 
   const handlePress = () => {


### PR DESCRIPTION
The default animation feels a bit slow for some scenarios, having a prop to customize will be very helpful.
As well, the ` thumbButton ` does not render correctly when the initial value is set to `true` since the `updateThumbButton` function is only being called when `onPress` is triggered. I changed the function to be called on any `toggleValue` state change and added another effect to allow the component to be controlled by external changes, this is useful when you want the toggle to be sync with other states.